### PR TITLE
feat(dynamodb-datasource): create DynamoDBCache and DynamoDBDataSource

### DIFF
--- a/jest-dynalite-config.json
+++ b/jest-dynalite-config.json
@@ -1,0 +1,29 @@
+{
+  "tables": [
+    {
+      "TableName": "test_hash_only",
+      "KeySchema": [{ "AttributeName": "id", "KeyType": "HASH" }],
+      "AttributeDefinitions": [{ "AttributeName": "id", "AttributeType": "S" }],
+      "ProvisionedThroughput": {
+        "ReadCapacityUnits": 1,
+        "WriteCapacityUnits": 1
+      }
+    },
+    {
+      "TableName": "test_composite",
+      "KeySchema": [
+        { "AttributeName": "id", "KeyType": "HASH" },
+        { "AttributeName": "timestamp", "KeyType": "RANGE" }
+      ],
+      "AttributeDefinitions": [
+        { "AttributeName": "id", "AttributeType": "S" },
+        { "AttributeName": "timestamp", "AttributeType": "S" }
+      ],
+      "ProvisionedThroughput": {
+        "ReadCapacityUnits": 1,
+        "WriteCapacityUnits": 1
+      }
+    }
+  ],
+  "basePort": 8000
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,9 +3,11 @@ module.exports = {
   transform: {
     '^.+\\.ts?$': 'ts-jest',
   },
-  testRegex: '(test|spec)\\.ts$',
+  preset: 'jest-dynalite',
+  testRegex: '/__tests__/.*\\.spec\\.ts$',
+  testPathIgnorePatterns: ['/node_modules/', '/lib/'],
   collectCoverage: true,
-  collectCoverageFrom: ['**/src/**/*', '!**/node_modules/'],
+  collectCoverageFrom: ['**/src/**/*', '!**/node_modules/', '!**/src/index.ts'],
   coverageThreshold: {
     global: {
       branches: 95,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1961,6 +1961,17 @@
       "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
       "dev": true
     },
+    "abstract-leveldown": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.2.tgz",
+      "integrity": "sha512-/a+Iwj0rn//CX0EJOasNyZJd2o8xur8Ce9C57Sznti/Ilt/cb6Qd8/k98A4ZOklXgTG+iAYYUs1OTG0s1eH+zQ==",
+      "dev": true,
+      "requires": {
+        "level-concat-iterator": "~2.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
+      }
+    },
     "acorn": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
@@ -2225,6 +2236,15 @@
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
+    "async": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+      "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
     "async-each": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
@@ -2242,6 +2262,58 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true
+    },
+    "aws-sdk": {
+      "version": "2.642.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.642.0.tgz",
+      "integrity": "sha512-0ZNgL1HBXRVobFD9Z64RyQk50cNABDMU1GV4lYIAvao4urYqYJi2MEVQmq+7WyXyzkBWu3lAPNDiJ8WW7emTzg==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        },
+        "url": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+          "requires": {
+            "punycode": "1.3.2",
+            "querystring": "0.2.0"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -2614,8 +2686,7 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "dev": true
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -2838,6 +2909,12 @@
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
       }
+    },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -3959,6 +4036,11 @@
         "whatwg-url": "^7.0.0"
       }
     },
+    "dataloader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-2.0.0.tgz",
+      "integrity": "sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ=="
+    },
     "debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -3985,6 +4067,16 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
+    },
+    "deferred-leveldown": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
+      "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
+      "dev": true,
+      "requires": {
+        "abstract-leveldown": "~6.2.1",
+        "inherits": "^2.0.3"
+      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -4034,6 +4126,12 @@
           }
         }
       }
+    },
+    "defined": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-0.0.0.tgz",
+      "integrity": "sha1-817qfXBekzuvE7LwOz+D2SFAOz4=",
+      "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -4110,6 +4208,25 @@
         "stream-shift": "^1.0.0"
       }
     },
+    "dynalite": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/dynalite/-/dynalite-3.1.5.tgz",
+      "integrity": "sha512-L3NdMAfSZCxqoZJFktkFbuG35b61lMAArwjH3xoIdag/p2dOYT4jgFbpvmvfAyxj6nAEC2Qg1LS49hYWXREY0Q==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.3",
+        "big.js": "^5.2.2",
+        "buffer-crc32": "^0.2.13",
+        "lazy": "^1.0.11",
+        "leveldown": "^5.2.1",
+        "levelup": "^4.3.2",
+        "lock": "^1.1.0",
+        "memdown": "^5.1.0",
+        "minimist": "^1.2.0",
+        "once": "^1.4.0",
+        "subleveldown": "^4.1.4"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -4152,6 +4269,18 @@
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
       "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
       "dev": true
+    },
+    "encoding-down": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
+      "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
+      "dev": true,
+      "requires": {
+        "abstract-leveldown": "^6.2.1",
+        "inherits": "^2.0.3",
+        "level-codec": "^9.0.0",
+        "level-errors": "^2.0.0"
+      }
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -5146,6 +5275,14 @@
       "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
       "dev": true
     },
+    "graphql": {
+      "version": "14.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.6.0.tgz",
+      "integrity": "sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==",
+      "requires": {
+        "iterall": "^1.2.2"
+      }
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -5324,8 +5461,7 @@
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-      "dev": true
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
     "iferr": {
       "version": "0.1.5",
@@ -5337,6 +5473,12 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
       "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "immediate": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
+      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw=",
       "dev": true
     },
     "import-fresh": {
@@ -5746,8 +5888,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -5867,6 +6008,11 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
+    },
+    "iterall": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
+      "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
     },
     "jest": {
       "version": "25.1.0",
@@ -6245,6 +6391,930 @@
       "dev": true,
       "requires": {
         "detect-newline": "^3.0.0"
+      }
+    },
+    "jest-dynalite": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/jest-dynalite/-/jest-dynalite-1.1.6.tgz",
+      "integrity": "sha512-G/9DVJQWjf365jnnLwA4NMZVY/cAOgt1zXK0RJ7oK9fXsbj0jnaNsUyLUoqFOC+YnrfqohQRH5F1KdtHR3Lj7w==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^24.9.0",
+        "dynalite": "^3.0.0",
+        "jest-environment-node": "^24.9.0"
+      },
+      "dependencies": {
+        "@jest/console": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
+          "integrity": "sha512-Zuj6b8TnKXi3q4ymac8EQfc3ea/uhLeCGThFqXeC8H9/raaH8ARPUTdId+XyGd03Z4In0/VjD2OYFcBF09fNLQ==",
+          "dev": true,
+          "requires": {
+            "@jest/source-map": "^24.9.0",
+            "chalk": "^2.0.1",
+            "slash": "^2.0.0"
+          }
+        },
+        "@jest/environment": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-24.9.0.tgz",
+          "integrity": "sha512-5A1QluTPhvdIPFYnO3sZC3smkNeXPVELz7ikPbhUj0bQjB07EoE9qtLrem14ZUYWdVayYbsjVwIiL4WBIMV4aQ==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "^24.9.0",
+            "@jest/transform": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "jest-mock": "^24.9.0"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-24.9.0.tgz",
+          "integrity": "sha512-eWQcNa2YSwzXWIMC5KufBh3oWRIijrQFROsIqt6v/NS9Io/gknw1jsAC9c+ih/RQX4A3O7SeWAhQeN0goKhT9A==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "jest-message-util": "^24.9.0",
+            "jest-mock": "^24.9.0"
+          }
+        },
+        "@jest/source-map": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-24.9.0.tgz",
+          "integrity": "sha512-/Xw7xGlsZb4MJzNDgB7PW5crou5JqWiBQaz6xyPd3ArOg2nfn/PunV8+olXbbEZzNl591o5rWKE9BRDaFAuIBg==",
+          "dev": true,
+          "requires": {
+            "callsites": "^3.0.0",
+            "graceful-fs": "^4.1.15",
+            "source-map": "^0.6.0"
+          }
+        },
+        "@jest/test-result": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-24.9.0.tgz",
+          "integrity": "sha512-XEFrHbBonBJ8dGp2JmF8kP/nQI/ImPpygKHwQ/SY+es59Z3L5PI4Qb9TQQMAEeYsThG1xF0k6tmG0tIKATNiiA==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "@types/istanbul-lib-coverage": "^2.0.0"
+          }
+        },
+        "@jest/transform": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-24.9.0.tgz",
+          "integrity": "sha512-TcQUmyNRxV94S0QpMOnZl0++6RMiqpbH/ZMccFB/amku6Uwvyb1cjYX7xkp5nGNkbX4QPH/FcB6q1HBTHynLmQ==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/types": "^24.9.0",
+            "babel-plugin-istanbul": "^5.1.0",
+            "chalk": "^2.0.1",
+            "convert-source-map": "^1.4.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "graceful-fs": "^4.1.15",
+            "jest-haste-map": "^24.9.0",
+            "jest-regex-util": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "micromatch": "^3.1.10",
+            "pirates": "^4.0.1",
+            "realpath-native": "^1.1.0",
+            "slash": "^2.0.0",
+            "source-map": "^0.6.1",
+            "write-file-atomic": "2.4.1"
+          }
+        },
+        "@jest/types": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+          "integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^13.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "13.0.8",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.8.tgz",
+          "integrity": "sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "anymatch": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+          "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+          "dev": true,
+          "requires": {
+            "micromatch": "^3.1.4",
+            "normalize-path": "^2.1.1"
+          }
+        },
+        "babel-plugin-istanbul": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-5.2.0.tgz",
+          "integrity": "sha512-5LphC0USA8t4i1zCtjbbNb6jJj/9+X6P37Qfirc/70EQ34xKlMW+a1RHGwxGI+SwWpNwZ27HqvzAobeqaXwiZw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-plugin-utils": "^7.0.0",
+            "find-up": "^3.0.0",
+            "istanbul-lib-instrument": "^3.3.0",
+            "test-exclude": "^5.2.3"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.12",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
+          "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1",
+            "node-pre-gyp": "*"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.1.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "3.2.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.7",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.6.0"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "1.2.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.3.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.9.0"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "minimist": "^1.2.5"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.3.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "debug": "^3.2.6",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.14.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4.4.2"
+              }
+            },
+            "nopt": {
+              "version": "4.0.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "npm-normalize-package-bin": "^1.0.1"
+              }
+            },
+            "npm-normalize-package-bin": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.4.8",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1",
+                "npm-normalize-package-bin": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.8",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.7.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.7.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.13",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.8.6",
+                "minizlib": "^1.2.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.3"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.3",
+              "bundled": true,
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2 || 2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            },
+            "yallist": {
+              "version": "3.1.1",
+              "bundled": true,
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "istanbul-lib-coverage": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+          "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+          "dev": true
+        },
+        "istanbul-lib-instrument": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+          "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
+          "dev": true,
+          "requires": {
+            "@babel/generator": "^7.4.0",
+            "@babel/parser": "^7.4.3",
+            "@babel/template": "^7.4.0",
+            "@babel/traverse": "^7.4.3",
+            "@babel/types": "^7.4.0",
+            "istanbul-lib-coverage": "^2.0.5",
+            "semver": "^6.0.0"
+          }
+        },
+        "jest-environment-node": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-24.9.0.tgz",
+          "integrity": "sha512-6d4V2f4nxzIzwendo27Tr0aFm+IXWa0XEUnaH6nU0FMaozxovt+sfRvh4J47wL1OvF83I3SSTu0XK+i4Bqe7uA==",
+          "dev": true,
+          "requires": {
+            "@jest/environment": "^24.9.0",
+            "@jest/fake-timers": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "jest-mock": "^24.9.0",
+            "jest-util": "^24.9.0"
+          }
+        },
+        "jest-haste-map": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-24.9.0.tgz",
+          "integrity": "sha512-kfVFmsuWui2Sj1Rp1AJ4D9HqJwE4uwTlS/vO+eRUaMmd54BFpli2XhMQnPC2k4cHFVbB2Q2C+jtI1AGLgEnCjQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.9.0",
+            "anymatch": "^2.0.0",
+            "fb-watchman": "^2.0.0",
+            "fsevents": "^1.2.7",
+            "graceful-fs": "^4.1.15",
+            "invariant": "^2.2.4",
+            "jest-serializer": "^24.9.0",
+            "jest-util": "^24.9.0",
+            "jest-worker": "^24.9.0",
+            "micromatch": "^3.1.10",
+            "sane": "^4.0.3",
+            "walker": "^1.0.7"
+          }
+        },
+        "jest-message-util": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-24.9.0.tgz",
+          "integrity": "sha512-oCj8FiZ3U0hTP4aSui87P4L4jC37BtQwUMqk+zk/b11FR19BJDeZsZAvIHutWnmtw7r85UmR3CEWZ0HWU2mAlw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "@jest/test-result": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "@types/stack-utils": "^1.0.1",
+            "chalk": "^2.0.1",
+            "micromatch": "^3.1.10",
+            "slash": "^2.0.0",
+            "stack-utils": "^1.0.1"
+          }
+        },
+        "jest-mock": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-24.9.0.tgz",
+          "integrity": "sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^24.9.0"
+          }
+        },
+        "jest-regex-util": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-24.9.0.tgz",
+          "integrity": "sha512-05Cmb6CuxaA+Ys6fjr3PhvV3bGQmO+2p2La4hFbU+W5uOc479f7FdLXUWXw4pYMAhhSZIuKHwSXSu6CsSBAXQA==",
+          "dev": true
+        },
+        "jest-serializer": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
+          "integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ==",
+          "dev": true
+        },
+        "jest-util": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-24.9.0.tgz",
+          "integrity": "sha512-x+cZU8VRmOJxbA1K5oDBdxQmdq0OIdADarLxk0Mq+3XS4jgvhG/oKGWcIDCtPG0HgjxOYvF+ilPJQsAyXfbNOg==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^24.9.0",
+            "@jest/fake-timers": "^24.9.0",
+            "@jest/source-map": "^24.9.0",
+            "@jest/test-result": "^24.9.0",
+            "@jest/types": "^24.9.0",
+            "callsites": "^3.0.0",
+            "chalk": "^2.0.1",
+            "graceful-fs": "^4.1.15",
+            "is-ci": "^2.0.0",
+            "mkdirp": "^0.5.1",
+            "slash": "^2.0.0",
+            "source-map": "^0.6.0"
+          }
+        },
+        "jest-worker": {
+          "version": "24.9.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-24.9.0.tgz",
+          "integrity": "sha512-51PE4haMSXcHohnSMdM42anbvZANYTqMrr52tVKPqqsPJMzoP6FYYDVqahX/HrAoKEKz3uUPzSvKs9A3qR4iVw==",
+          "dev": true,
+          "requires": {
+            "merge-stream": "^2.0.0",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "normalize-path": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+          "dev": true,
+          "requires": {
+            "remove-trailing-separator": "^1.0.1"
+          }
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^4.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
+          "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
+          "dev": true,
+          "requires": {
+            "find-up": "^3.0.0",
+            "read-pkg": "^3.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "slash": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        },
+        "test-exclude": {
+          "version": "5.2.3",
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-5.2.3.tgz",
+          "integrity": "sha512-M+oxtseCFO3EDtAaGH7iiej3CBkzXqFMbzqYAACdzKui4eZA+pq3tZEwChvOdNfa7xxy8BfbmgJSIr43cC/+2g==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3",
+            "minimatch": "^3.0.4",
+            "read-pkg-up": "^4.0.0",
+            "require-main-filename": "^2.0.0"
+          }
+        },
+        "write-file-atomic": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.1.tgz",
+          "integrity": "sha512-TGHFeZEZMnv+gBFRfjAcxL5bPHrsGKtnb4qsFAws7/vlh+QfwAaySIw4AXP9ZskTTh5GWu3FLuJhsWVdiJPGvg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.2"
+          }
+        }
       }
     },
     "jest-each": {
@@ -7246,6 +8316,11 @@
         }
       }
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7371,6 +8446,100 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "lazy": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/lazy/-/lazy-1.0.11.tgz",
+      "integrity": "sha1-2qBoIGKCVCwIgojpdcKXwa53tpA=",
+      "dev": true
+    },
+    "level-codec": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
+      "integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q==",
+      "dev": true
+    },
+    "level-concat-iterator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
+      "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==",
+      "dev": true
+    },
+    "level-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
+      "dev": true,
+      "requires": {
+        "errno": "~0.1.1"
+      }
+    },
+    "level-iterator-stream": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
+      "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
+      "dev": true,
+      "requires": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0",
+        "xtend": "^4.0.2"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "level-option-wrap": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/level-option-wrap/-/level-option-wrap-1.1.0.tgz",
+      "integrity": "sha1-rSDmjZ88IsiJdTHMaqevWWse0Sk=",
+      "dev": true,
+      "requires": {
+        "defined": "~0.0.0"
+      }
+    },
+    "level-supports": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
+      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
+      "dev": true,
+      "requires": {
+        "xtend": "^4.0.2"
+      }
+    },
+    "leveldown": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.5.1.tgz",
+      "integrity": "sha512-GoC455/ncfg4yLLItr192HuXpA+CcQ2q9GncXJhewvvlpsBBEegChn5tMPP+kGvJt7u2LuXAd8fY2moQxFD+sQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "abstract-leveldown": "~6.2.1",
+        "napi-macros": "~2.0.0",
+        "node-gyp-build": "~4.1.0"
+      }
+    },
+    "levelup": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.3.2.tgz",
+      "integrity": "sha512-cRTjU4ktWo59wf13PHEiOayHC3n0dOh4i5+FHr4tv4MX9+l7mqETicNq3Aj07HKlLdk0z5muVoDL2RD+ovgiyA==",
+      "dev": true,
+      "requires": {
+        "deferred-leveldown": "~5.3.0",
+        "level-errors": "~2.0.0",
+        "level-iterator-stream": "~4.0.0",
+        "level-supports": "~1.0.0",
+        "xtend": "~4.0.0"
+      }
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -7454,6 +8623,12 @@
         "path-exists": "^3.0.0"
       }
     },
+    "lock": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/lock/-/lock-1.1.0.tgz",
+      "integrity": "sha1-UxV0mdFlOxNspmRRBx/KYVcD+lU=",
+      "dev": true
+    },
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -7497,6 +8672,12 @@
       "requires": {
         "yallist": "^3.0.2"
       }
+    },
+    "ltgt": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU=",
+      "dev": true
     },
     "make-dir": {
       "version": "2.1.0",
@@ -7553,6 +8734,28 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "memdown": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/memdown/-/memdown-5.1.0.tgz",
+      "integrity": "sha512-B3J+UizMRAlEArDjWHTMmadet+UKwHd3UjMgGBkZcKAxAYVPS9o0Yeiha4qvz7iGiL2Sb3igUft6p7nbFWctpw==",
+      "dev": true,
+      "requires": {
+        "abstract-leveldown": "~6.2.1",
+        "functional-red-black-tree": "~1.0.1",
+        "immediate": "~3.2.3",
+        "inherits": "~2.0.1",
+        "ltgt": "~2.2.0",
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+          "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+          "dev": true
+        }
       }
     },
     "memory-fs": {
@@ -7767,6 +8970,13 @@
         "to-regex": "^3.0.1"
       }
     },
+    "napi-macros": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
+      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
+      "dev": true,
+      "optional": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -7789,6 +8999,13 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
+    "node-gyp-build": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
+      "integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ==",
+      "dev": true,
+      "optional": true
     },
     "node-int64": {
       "version": "0.4.0",
@@ -8446,8 +9663,7 @@
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-      "dev": true
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "querystring-es3": {
       "version": "0.2.1",
@@ -8473,6 +9689,12 @@
         "randombytes": "^2.0.5",
         "safe-buffer": "^5.1.0"
       }
+    },
+    "reachdown": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/reachdown/-/reachdown-1.0.0.tgz",
+      "integrity": "sha512-Ty7X/t52GwgRam3SMpZC2grmutuUarkiD4sVhjM8g8/5NlX8PAEsYO/pyx6nTTqS9udee1j1BxaAS/f6Rm8SMw==",
+      "dev": true
     },
     "react-is": {
       "version": "16.13.0",
@@ -8931,6 +10153,11 @@
           }
         }
       }
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "saxes": {
       "version": "3.1.11",
@@ -9500,6 +10727,20 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
       "integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
       "dev": true
+    },
+    "subleveldown": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/subleveldown/-/subleveldown-4.1.4.tgz",
+      "integrity": "sha512-njpSBP/Bxh7EahraG6IhR6goOH2ffMTMVt7Ud+k/OhNFHrrmuvK+XYfauI8KnjCm0w381cUF43pejlWeJMZChA==",
+      "dev": true,
+      "requires": {
+        "abstract-leveldown": "^6.1.1",
+        "encoding-down": "^6.2.0",
+        "inherits": "^2.0.3",
+        "level-option-wrap": "^1.1.0",
+        "levelup": "^4.3.1",
+        "reachdown": "^1.0.0"
+      }
     },
     "supports-color": {
       "version": "5.5.0",
@@ -10484,6 +11725,20 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,10 @@
     "@babel/plugin-proposal-optional-chaining": "^7.8.3",
     "apollo-datasource": "^0.7.0",
     "apollo-server-caching": "^0.5.1",
-    "apollo-server-errors": "^2.4.0"
+    "apollo-server-errors": "^2.4.0",
+    "aws-sdk": "^2.642.0",
+    "dataloader": "^2.0.0",
+    "graphql": "^14.6.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.7",
@@ -78,6 +81,7 @@
     "eslint-plugin-prettier": "^3.1.2",
     "fork-ts-checker-webpack-plugin": "^4.1.0",
     "jest": "^25.1.0",
+    "jest-dynalite": "^1.1.6",
     "prettier": "^1.19.1",
     "rimraf": "^3.0.2",
     "ts-jest": "^25.2.1",

--- a/src/DynamoDBCache.ts
+++ b/src/DynamoDBCache.ts
@@ -1,0 +1,109 @@
+import { KeyValueCache, InMemoryLRUCache, PrefixingKeyValueCache } from 'apollo-server-caching';
+import { ApolloError } from 'apollo-server-errors';
+import { DynamoDB } from 'aws-sdk';
+
+import { buildCacheKey } from './utils';
+import { CacheKeyItemMap } from './types';
+
+export const CACHE_PREFIX_KEY = 'dynamodbcache:';
+export const TTL_SEC = 30 * 60; // the default time-to-live value for the cache in seconds
+
+export interface DynamoDBCache<T = unknown> {
+  getItem: (getItemInput: DynamoDB.DocumentClient.GetItemInput, ttl?: number) => Promise<T>;
+  setInCache: (key: string, item: T, ttl: number) => Promise<void>;
+  setItemsInCache: (items: CacheKeyItemMap<T>, ttl: number) => Promise<void>;
+  removeItemFromCache: (tableName: string, key: DynamoDB.DocumentClient.Key) => Promise<boolean | void>;
+}
+
+export class DynamoDBCacheImpl<T = unknown> implements DynamoDBCache<T> {
+  readonly keyValueCache: KeyValueCache;
+  readonly docClient: DynamoDB.DocumentClient;
+
+  /**
+   * Construct a new instance of `DynamoDBCache` with the given configuration
+   * @param docClient the DynamoDB.DocumentClient instance
+   * @param keyValueCache the key value caching client used to cache and retrieve records
+   */
+  constructor(docClient: DynamoDB.DocumentClient, keyValueCache: KeyValueCache = new InMemoryLRUCache()) {
+    this.keyValueCache = new PrefixingKeyValueCache(keyValueCache, CACHE_PREFIX_KEY);
+    this.docClient = docClient;
+  }
+
+  /**
+   * Attempt to retrieve the item from the KeyValueCache instance
+   * @param key the key of item in the cache
+   */
+  async retrieveFromCache(key: string): Promise<T | undefined> {
+    try {
+      const itemFromCache: string | undefined = await this.keyValueCache.get(key);
+      if (itemFromCache) {
+        return JSON.parse(itemFromCache) as T;
+      }
+    } catch (err) {
+      return undefined;
+    }
+    return undefined;
+  }
+
+  /**
+   * Set the found item in the cache instance
+   * @param key the key of the item to set in the cache
+   * @param item the item to store in the cache
+   * @param ttl cache time to live of the item
+   */
+  async setInCache(key: string, item: T, ttl: number = TTL_SEC): Promise<void> {
+    return await this.keyValueCache.set(key, JSON.stringify(item), { ttl });
+  }
+
+  /**
+   * Store all of the given items in the cache
+   * @param items the items to store in the cache. the object key value is the cache key
+   * @param ttl cache time to live of the item
+   */
+  async setItemsInCache(items: CacheKeyItemMap<T>, ttl: number = TTL_SEC): Promise<void> {
+    return Object.entries(items).forEach(async (item: [string, T]) => {
+      return await this.setInCache(item[0], item[1], ttl);
+    });
+  }
+
+  /**
+   * Retrieve the item with the given `GetItemInput`.
+   * - Attempt to retrieve the item from the cache.
+   * - If the item does not exist in the cache, retrieve the item from the table, then add the item to the cache
+   * @param getItemInput the input that provides information about which record to retrieve from the cache/dynamodb table
+   * @param ttl the time-to-live value of the item in the cache. determines how long the item persists in the cache
+   */
+  async getItem(getItemInput: DynamoDB.DocumentClient.GetItemInput, ttl?: number): Promise<T> {
+    try {
+      const cacheKey = buildCacheKey(CACHE_PREFIX_KEY, getItemInput.TableName, getItemInput.Key);
+      const itemFromCache: T | undefined = await this.retrieveFromCache(cacheKey);
+      if (itemFromCache) {
+        return itemFromCache;
+      }
+
+      // item is not in cache, retrieve from DynamoDB, if found, set in cache, otherwise throw ApolloError
+      const output: DynamoDB.DocumentClient.GetItemOutput = await this.docClient.get(getItemInput).promise();
+      const item: T | undefined = output.Item as T;
+
+      await this.setInCache(cacheKey, item, ttl);
+
+      return item;
+    } catch (err) {
+      throw new ApolloError(err?.message || 'An error occurred attempting to retrieve the item');
+    }
+  }
+
+  /**
+   * Remove an item from the cache.
+   * @param tableName the table name the item belong in. used to build the cache key
+   * @param key the dynamodb key value of the record. used to build the cache key
+   */
+  async removeItemFromCache(tableName: string, key: DynamoDB.DocumentClient.Key): Promise<boolean | void> {
+    try {
+      const cacheKey = buildCacheKey(CACHE_PREFIX_KEY, tableName, key);
+      return await this.keyValueCache.delete(cacheKey);
+    } catch (err) {
+      throw new ApolloError(err?.message || 'An error occurred trying to evict the item from the cache');
+    }
+  }
+}

--- a/src/DynamoDBDataSource.ts
+++ b/src/DynamoDBDataSource.ts
@@ -1,0 +1,157 @@
+import { DataSource, DataSourceConfig } from 'apollo-datasource';
+import { DynamoDB } from 'aws-sdk';
+import { ClientConfiguration } from 'aws-sdk/clients/dynamodb';
+
+import { DynamoDBCache, DynamoDBCacheImpl, CACHE_PREFIX_KEY } from './DynamoDBCache';
+import { buildItemsCacheMap, buildCacheKey, buildKey } from './utils';
+import { CacheKeyItemMap } from './types';
+
+export abstract class DynamoDBDataSource<ITEM = unknown, TContext = unknown> extends DataSource {
+  readonly dynamoDbDocClient: DynamoDB.DocumentClient;
+  readonly tableName!: string;
+  readonly tableKeySchema!: DynamoDB.DocumentClient.KeySchema;
+  dynamodbCache!: DynamoDBCache<ITEM>;
+  context!: TContext;
+
+  constructor(tableName: string, tableKeySchema: DynamoDB.DocumentClient.KeySchema, config?: ClientConfiguration) {
+    super();
+    this.tableName = tableName;
+    this.tableKeySchema = tableKeySchema;
+    this.dynamoDbDocClient = new DynamoDB.DocumentClient({
+      apiVersion: '2012-08-10',
+      ...config,
+    });
+  }
+
+  initialize({ context, cache }: DataSourceConfig<TContext>): void {
+    this.context = context;
+    this.dynamodbCache = new DynamoDBCacheImpl(this.dynamoDbDocClient, cache);
+    console.log('DynamoDBDataSource has been initialized with context', this.context);
+  }
+
+  /**
+   * Retrieve the item with the given `GetItemInput`.
+   * - Attempt to retrieve the item from the cache.
+   * - If the item does not exist in the cache, retrieve the item from the table, then add the item to the cache
+   * @param getItemInput the input that provides information about which record to retrieve from the cache/dynamodb table
+   * @param ttl the time-to-live value of the item in the cache. determines how long the item persists in the cache
+   */
+  async getItem(getItemInput: DynamoDB.DocumentClient.GetItemInput, ttl?: number): Promise<ITEM> {
+    return await this.dynamodbCache.getItem(getItemInput, ttl);
+  }
+
+  /**
+   * Query for a list of records by the given query input.
+   * If the ttl has a value, and items are returned, store the items in the cache
+   * @param queryInput the defined query that tells the document client which records to retrieve from the table
+   * @param ttl the time-to-live value of the item in the cache. determines how long the item persists in the cache
+   */
+  async query(queryInput: DynamoDB.DocumentClient.QueryInput, ttl?: number): Promise<ITEM[]> {
+    const output = await this.dynamoDbDocClient.query(queryInput).promise();
+    const items: ITEM[] = output.Items as ITEM[];
+
+    // store the items in the cache
+    if (items.length && ttl) {
+      const cacheKeyItemMap: CacheKeyItemMap<ITEM> = buildItemsCacheMap(
+        CACHE_PREFIX_KEY,
+        this.tableName,
+        this.tableKeySchema,
+        items
+      );
+      await this.dynamodbCache.setItemsInCache(cacheKeyItemMap, ttl);
+    }
+
+    return items;
+  }
+
+  /**
+   * Scan for a list of records by the given scan input.
+   * If the ttl has a value, and items are returned, store the items in the cache
+   * @param scanInput the scan input that tell the document client how to scan for records in the table
+   * @param ttl the time-to-live value of the item in the cache. determines how long the item persists in the cache
+   */
+  async scan(scanInput: DynamoDB.DocumentClient.ScanInput, ttl?: number): Promise<ITEM[]> {
+    const output = await this.dynamoDbDocClient.scan(scanInput).promise();
+    const items: ITEM[] = output.Items as ITEM[];
+
+    // store the items in the cache
+    if (items.length && ttl) {
+      const cacheKeyItemMap: CacheKeyItemMap<ITEM> = buildItemsCacheMap(
+        CACHE_PREFIX_KEY,
+        this.tableName,
+        this.tableKeySchema,
+        items
+      );
+      await this.dynamodbCache.setItemsInCache(cacheKeyItemMap, ttl);
+    }
+
+    return items;
+  }
+
+  /**
+   * Store the item in the table and add the item to the cache
+   * @param item the item to store in the table
+   * @param ttl the time-to-live value of how long to persist the item in the cache
+   */
+  async put(item: ITEM, ttl?: number): Promise<ITEM> {
+    const putItemInput: DynamoDB.DocumentClient.PutItemInput = {
+      TableName: this.tableName,
+      Item: item,
+    };
+    await this.dynamoDbDocClient.put(putItemInput).promise();
+
+    if (ttl) {
+      const key: DynamoDB.DocumentClient.Key = buildKey(this.tableKeySchema, item);
+      const cacheKey: string = buildCacheKey(CACHE_PREFIX_KEY, this.tableName, key);
+      await this.dynamodbCache.setInCache(cacheKey, item, ttl);
+    }
+
+    return item;
+  }
+
+  /**
+   * Update the item in the table and reset the item in the cache
+   * @param key the key of the item in the table to update
+   * @param ttl the time-to-live value of how long to persist the item in the cache
+   */
+  async update(
+    key: DynamoDB.DocumentClient.Key,
+    updateExpression: DynamoDB.DocumentClient.UpdateExpression,
+    expressionAttributeNames: DynamoDB.DocumentClient.ExpressionAttributeNameMap,
+    expressionAttributeValues: DynamoDB.DocumentClient.ExpressionAttributeValueMap,
+    ttl?: number
+  ): Promise<ITEM> {
+    const updateItemInput: DynamoDB.DocumentClient.UpdateItemInput = {
+      TableName: this.tableName,
+      Key: key,
+      ReturnValues: 'ALL_NEW',
+      UpdateExpression: updateExpression,
+      ExpressionAttributeNames: expressionAttributeNames,
+      ExpressionAttributeValues: expressionAttributeValues,
+    };
+    const output = await this.dynamoDbDocClient.update(updateItemInput).promise();
+    const updated: ITEM = output.Attributes as ITEM;
+
+    if (updated && ttl) {
+      const cacheKey: string = buildCacheKey(CACHE_PREFIX_KEY, this.tableName, key);
+      await this.dynamodbCache.setInCache(cacheKey, updated, ttl);
+    }
+
+    return updated;
+  }
+
+  /**
+   * Delete the given item from the table
+   * @param key the key of the item to delete from the table
+   */
+  async delete(key: DynamoDB.DocumentClient.Key): Promise<void> {
+    const deleteItemInput: DynamoDB.DocumentClient.DeleteItemInput = {
+      TableName: this.tableName,
+      Key: key,
+    };
+
+    await this.dynamoDbDocClient.delete(deleteItemInput).promise();
+
+    await this.dynamodbCache.removeItemFromCache(this.tableName, key);
+  }
+}

--- a/src/__tests__/DynamoDBCache.spec.ts
+++ b/src/__tests__/DynamoDBCache.spec.ts
@@ -1,0 +1,284 @@
+import { ApolloError } from 'apollo-server-errors';
+import { DynamoDB } from 'aws-sdk';
+
+import { DynamoDBCacheImpl, CACHE_PREFIX_KEY, TTL_SEC } from '../DynamoDBCache';
+import { buildCacheKey } from '../utils';
+
+const { MOCK_DYNAMODB_ENDPOINT } = process.env;
+
+interface TestHashOnlyItem {
+  id: string;
+  test: string;
+}
+
+describe('DynamoDBCache', () => {
+  const docClient = new DynamoDB.DocumentClient({
+    region: 'local',
+    endpoint: MOCK_DYNAMODB_ENDPOINT,
+    sslEnabled: false,
+  });
+  describe('retrieveFromCache', () => {
+    const dynamodbCache = new DynamoDBCacheImpl(docClient);
+    const getFromCacheMock = jest.spyOn(dynamodbCache.keyValueCache, 'get');
+
+    afterEach(() => {
+      getFromCacheMock.mockReset();
+    });
+    afterAll(() => {
+      getFromCacheMock.mockRestore();
+    });
+
+    it('should return undefined if no item is found in the cache', async () => {
+      const given = `${CACHE_PREFIX_KEY}test:id-testId`;
+
+      getFromCacheMock.mockResolvedValueOnce(undefined);
+
+      const actual = await dynamodbCache.retrieveFromCache(given);
+
+      expect(actual).toEqual(undefined);
+      expect(getFromCacheMock).toBeCalledWith(given);
+    });
+
+    it('should return undefined if an error is thrown retrieving an item from the cache', async () => {
+      const given = `${CACHE_PREFIX_KEY}test:id-testId`;
+
+      getFromCacheMock.mockRejectedValueOnce(new Error('Error retrieving item from cache'));
+
+      const actual = await dynamodbCache.retrieveFromCache(given);
+
+      expect(actual).toEqual(undefined);
+      expect(getFromCacheMock).toBeCalledWith(given);
+    });
+
+    it('should return the parsed item from the cache', async () => {
+      const given = `${CACHE_PREFIX_KEY}test:id-testId`;
+      const expected = {
+        id: 'testId',
+        test: 'test',
+      };
+      const itemFromCache = JSON.stringify(expected);
+
+      getFromCacheMock.mockResolvedValueOnce(itemFromCache);
+
+      const actual = await dynamodbCache.retrieveFromCache(given);
+
+      expect(actual).toEqual(expected);
+      expect(getFromCacheMock).toBeCalledWith(given);
+    });
+  });
+
+  describe('setInCache', () => {
+    const dynamodbCache = new DynamoDBCacheImpl(docClient);
+    const setInCacheMock = jest.spyOn(dynamodbCache.keyValueCache, 'set');
+
+    afterEach(() => {
+      setInCacheMock.mockReset();
+    });
+    afterAll(() => {
+      setInCacheMock.mockRestore();
+    });
+
+    it('should set the item in the cache with default TTL', async () => {
+      const givenKey = `${CACHE_PREFIX_KEY}test:id-testId`;
+      const givenItem = {
+        id: 'testId',
+        test: 'test',
+      };
+
+      setInCacheMock.mockResolvedValueOnce();
+
+      await dynamodbCache.setInCache(givenKey, givenItem);
+
+      expect(setInCacheMock).toBeCalledWith(givenKey, JSON.stringify(givenItem), { ttl: TTL_SEC });
+    });
+  });
+
+  describe('setItemsInCache', () => {
+    const dynamodbCache = new DynamoDBCacheImpl(docClient);
+    const setInCacheMock = jest.spyOn(dynamodbCache, 'setInCache');
+
+    afterEach(() => {
+      setInCacheMock.mockReset();
+    });
+    afterAll(() => {
+      setInCacheMock.mockRestore();
+    });
+
+    it('should set the item in the cache with default TTL', async () => {
+      const givenKey = `${CACHE_PREFIX_KEY}test:id-testId`;
+      const givenItem = {
+        id: 'testId',
+        test: 'test',
+      };
+      const given: { [cacheKey: string]: TestHashOnlyItem } = {
+        [givenKey]: givenItem,
+      };
+
+      setInCacheMock.mockResolvedValueOnce();
+
+      await dynamodbCache.setItemsInCache(given);
+
+      expect(setInCacheMock).toBeCalledTimes(Object.keys(given).length);
+      expect(setInCacheMock).toBeCalledWith(givenKey, givenItem, TTL_SEC);
+    });
+  });
+
+  describe('getItem', () => {
+    const dynamodbCache = new DynamoDBCacheImpl<TestHashOnlyItem>(docClient);
+    const testHashOnlyTableName = 'test_hash_only';
+    const testHashOnlyItem: TestHashOnlyItem = { id: 'testId', test: 'testing' };
+    const retrieveFromCacheMock = jest.spyOn(dynamodbCache, 'retrieveFromCache');
+    const setInCacheMock = jest.spyOn(dynamodbCache, 'setInCache');
+
+    afterEach(() => {
+      retrieveFromCacheMock.mockReset();
+      setInCacheMock.mockReset();
+    });
+    afterAll(async () => {
+      retrieveFromCacheMock.mockRestore();
+      setInCacheMock.mockRestore();
+    });
+
+    it('should return the item retrieved from the cache', async () => {
+      const givenGetItemInput: DynamoDB.DocumentClient.GetItemInput = {
+        TableName: testHashOnlyTableName,
+        ConsistentRead: true,
+        Key: { id: 'testId' },
+      };
+      const givenTtl = TTL_SEC;
+      const expected = testHashOnlyItem;
+      const cacheKey = buildCacheKey(CACHE_PREFIX_KEY, testHashOnlyTableName, { id: 'testId' });
+
+      retrieveFromCacheMock.mockResolvedValueOnce(expected);
+
+      const actual: TestHashOnlyItem = await dynamodbCache.getItem(givenGetItemInput, givenTtl);
+
+      expect(actual).toEqual(expected);
+      expect(retrieveFromCacheMock).toBeCalledWith(cacheKey);
+      expect(setInCacheMock).not.toBeCalled();
+    });
+
+    it('should return the item retrieved from the DynamoDB table and set in the cache', async () => {
+      const givenGetItemInput: DynamoDB.DocumentClient.GetItemInput = {
+        TableName: testHashOnlyTableName,
+        ConsistentRead: true,
+        Key: { id: 'testId' },
+      };
+      const givenTtl = TTL_SEC;
+      await dynamodbCache.docClient
+        .put({
+          TableName: testHashOnlyTableName,
+          Item: testHashOnlyItem,
+        })
+        .promise();
+      const cacheKey = buildCacheKey(CACHE_PREFIX_KEY, testHashOnlyTableName, { id: 'testId' });
+
+      retrieveFromCacheMock.mockResolvedValueOnce(undefined);
+      setInCacheMock.mockResolvedValueOnce();
+
+      const { Item } = await dynamodbCache.docClient.get(givenGetItemInput).promise();
+      const actual: TestHashOnlyItem = await dynamodbCache.getItem(givenGetItemInput, givenTtl);
+
+      expect(actual).toBeDefined();
+      expect(actual).toEqual(Item);
+      expect(actual).toEqual(testHashOnlyItem);
+      expect(retrieveFromCacheMock).toBeCalledWith(cacheKey);
+      expect(setInCacheMock).toBeCalledWith(cacheKey, actual, givenTtl);
+
+      await dynamodbCache.docClient
+        .delete({
+          TableName: testHashOnlyTableName,
+          Key: { id: 'testId' },
+        })
+        .promise();
+    });
+
+    it('should return an ApolloError if an error is thrown retrieving the record', async () => {
+      const givenGetItemInput: DynamoDB.DocumentClient.GetItemInput = {
+        TableName: testHashOnlyTableName,
+        ConsistentRead: true,
+        Key: { id: 'testId' },
+      };
+      const givenTtl = TTL_SEC;
+      const cacheKey = buildCacheKey(CACHE_PREFIX_KEY, testHashOnlyTableName, { id: 'testId' });
+      const error = new Error('Error setting item in cache');
+
+      retrieveFromCacheMock.mockRejectedValueOnce(error);
+
+      await expect(dynamodbCache.getItem(givenGetItemInput, givenTtl)).rejects.toThrowError(
+        new ApolloError('Error setting item in cache')
+      );
+      expect(retrieveFromCacheMock).toBeCalledWith(cacheKey);
+      expect(setInCacheMock).not.toBeCalled();
+    });
+
+    it('should return an ApolloError if no record is found', async () => {
+      const givenGetItemInput: DynamoDB.DocumentClient.GetItemInput = {
+        TableName: testHashOnlyTableName,
+        ConsistentRead: true,
+        Key: { id: 'does_not_exist' },
+      };
+      const givenTtl = TTL_SEC;
+      const cacheKey = buildCacheKey(CACHE_PREFIX_KEY, testHashOnlyTableName, { id: 'does_not_exist' });
+
+      retrieveFromCacheMock.mockRejectedValueOnce(undefined);
+
+      await expect(dynamodbCache.getItem(givenGetItemInput, givenTtl)).rejects.toThrowError(
+        new ApolloError('An error occurred attempting to retrieve the item')
+      );
+      expect(retrieveFromCacheMock).toBeCalledWith(cacheKey);
+      expect(setInCacheMock).not.toBeCalled();
+    });
+  });
+
+  describe('removeItemFromCache', () => {
+    const dynamodbCache = new DynamoDBCacheImpl<TestHashOnlyItem>(docClient);
+    const deleteFromCacheMock = jest.spyOn(dynamodbCache.keyValueCache, 'delete');
+
+    afterEach(() => {
+      deleteFromCacheMock.mockReset();
+    });
+    afterAll(() => {
+      deleteFromCacheMock.mockRestore();
+    });
+
+    it('should remove the item from the cache and return true', async () => {
+      const givenTableName = 'test';
+      const givenKey: DynamoDB.DocumentClient.Key = { id: 'testId' };
+      const givenCacheKey = `${CACHE_PREFIX_KEY}test:id-testId`;
+
+      deleteFromCacheMock.mockResolvedValueOnce(true);
+
+      const actual = await dynamodbCache.removeItemFromCache(givenTableName, givenKey);
+
+      expect(actual).toEqual(true);
+      expect(deleteFromCacheMock).toBeCalledWith(givenCacheKey);
+    });
+
+    it('should throw an ApolloError if the dynamodbCache.keyValueCache.delete throws an error - with given error message', async () => {
+      const givenTableName = 'test';
+      const givenKey: DynamoDB.DocumentClient.Key = { id: 'testId' };
+      const givenCacheKey = `${CACHE_PREFIX_KEY}test:id-testId`;
+
+      deleteFromCacheMock.mockRejectedValueOnce(new Error('Error'));
+
+      await expect(dynamodbCache.removeItemFromCache(givenTableName, givenKey)).rejects.toThrowError(
+        new ApolloError('Error')
+      );
+      expect(deleteFromCacheMock).toBeCalledWith(givenCacheKey);
+    });
+
+    it('should throw an ApolloError if the dynamodbCache.keyValueCache.delete throws an error - with default error message', async () => {
+      const givenTableName = 'test';
+      const givenKey: DynamoDB.DocumentClient.Key = { id: 'testId' };
+      const givenCacheKey = `${CACHE_PREFIX_KEY}test:id-testId`;
+
+      deleteFromCacheMock.mockRejectedValueOnce(null);
+
+      await expect(dynamodbCache.removeItemFromCache(givenTableName, givenKey)).rejects.toThrowError(
+        new ApolloError('An error occurred trying to evict the item from the cache')
+      );
+      expect(deleteFromCacheMock).toBeCalledWith(givenCacheKey);
+    });
+  });
+});

--- a/src/__tests__/DynamoDBDataSource.spec.ts
+++ b/src/__tests__/DynamoDBDataSource.spec.ts
@@ -1,0 +1,466 @@
+import { ApolloError } from 'apollo-server-errors';
+import { DataSourceConfig } from 'apollo-datasource';
+import { DynamoDB } from 'aws-sdk';
+import { ClientConfiguration } from 'aws-sdk/clients/dynamodb';
+
+import { DynamoDBDataSource } from '../DynamoDBDataSource';
+import { CACHE_PREFIX_KEY } from '../DynamoDBCache';
+import { buildItemsCacheMap } from '../utils';
+import { CacheKeyItemMap } from '../types';
+
+const { MOCK_DYNAMODB_ENDPOINT } = process.env;
+
+interface TestHashOnlyItem {
+  id: string;
+  test: string;
+}
+
+class TestHashOnly extends DynamoDBDataSource<TestHashOnlyItem> {
+  constructor(tableName: string, tableKeySchema: DynamoDB.DocumentClient.KeySchema, config?: ClientConfiguration) {
+    super(tableName, tableKeySchema, config);
+  }
+
+  initialize(config: DataSourceConfig<{}>): void {
+    super.initialize(config);
+  }
+}
+
+const keySchema: DynamoDB.DocumentClient.KeySchema = [
+  {
+    AttributeName: 'id',
+    KeyType: 'HASH',
+  },
+];
+const testHashOnly = new TestHashOnly('test_hash_only', keySchema, {
+  region: 'local',
+  endpoint: MOCK_DYNAMODB_ENDPOINT,
+  sslEnabled: false,
+});
+testHashOnly.initialize({ context: {}, cache: null });
+
+const testHashOnlyItem: TestHashOnlyItem = {
+  id: 'testId',
+  test: 'testing',
+};
+const items: TestHashOnlyItem[] = [testHashOnlyItem];
+
+beforeAll(async () => {
+  await testHashOnly.dynamoDbDocClient
+    .put({
+      TableName: testHashOnly.tableName,
+      Item: testHashOnlyItem,
+    })
+    .promise();
+});
+
+afterAll(async () => {
+  await testHashOnly.dynamoDbDocClient
+    .delete({
+      TableName: testHashOnly.tableName,
+      Key: { id: 'testId' },
+    })
+    .promise();
+});
+
+describe('DynamoDBDataSource', () => {
+  it('initializes a new TestHashOnly and instantiates props', () => {
+    expect(testHashOnly.dynamoDbDocClient).toBeDefined();
+    expect(testHashOnly.tableName).toBeDefined();
+    expect(testHashOnly.tableKeySchema).toBeDefined();
+    expect(testHashOnly.dynamodbCache).toBeDefined();
+  });
+
+  describe('getItem', () => {
+    const dynamodbCacheGetItemMock = jest.spyOn(testHashOnly.dynamodbCache, 'getItem');
+
+    afterEach(() => {
+      dynamodbCacheGetItemMock.mockReset();
+    });
+    afterAll(() => {
+      dynamodbCacheGetItemMock.mockRestore();
+    });
+
+    it('should return a TestHashOnly item', async () => {
+      const getItemInput: DynamoDB.DocumentClient.GetItemInput = {
+        TableName: testHashOnly.tableName,
+        ConsistentRead: true,
+        Key: {
+          id: 'testId',
+        },
+      };
+
+      dynamodbCacheGetItemMock.mockResolvedValueOnce(testHashOnlyItem);
+
+      const actual = await testHashOnly.getItem(getItemInput);
+
+      expect(actual).toEqual(testHashOnlyItem);
+      expect(dynamodbCacheGetItemMock).toBeCalledWith(getItemInput, undefined);
+    });
+
+    it('should throw an ApolloError if an issue occurs retrieving the record', async () => {
+      const getItemInput: DynamoDB.DocumentClient.GetItemInput = {
+        TableName: testHashOnly.tableName,
+        ConsistentRead: true,
+        Key: {
+          id: 'testId',
+        },
+      };
+
+      dynamodbCacheGetItemMock.mockRejectedValueOnce(new ApolloError('Error'));
+
+      await expect(testHashOnly.getItem(getItemInput)).rejects.toThrowError(new ApolloError('Error'));
+      expect(dynamodbCacheGetItemMock).toBeCalledWith(getItemInput, undefined);
+    });
+  });
+
+  const dynamodbCacheSetItemsInCacheMock = jest.spyOn(testHashOnly.dynamodbCache, 'setItemsInCache');
+  const dynamodbCacheSetInCacheMock = jest.spyOn(testHashOnly.dynamodbCache, 'setInCache');
+
+  afterEach(() => {
+    dynamodbCacheSetItemsInCacheMock.mockReset();
+    dynamodbCacheSetInCacheMock.mockReset();
+  });
+  afterAll(() => {
+    dynamodbCacheSetItemsInCacheMock.mockRestore();
+    dynamodbCacheSetInCacheMock.mockRestore();
+  });
+
+  it('query should return a list of TestHashOnlyItem records and add items to the cache', async () => {
+    const queryInput: DynamoDB.DocumentClient.QueryInput = {
+      TableName: testHashOnly.tableName,
+      ConsistentRead: true,
+      KeyConditionExpression: 'id = :id',
+      ExpressionAttributeValues: {
+        ':id': 'testId',
+      },
+    };
+    const ttl = 30;
+
+    await testHashOnly.dynamoDbDocClient
+      .put({
+        TableName: testHashOnly.tableName,
+        Item: testHashOnlyItem,
+      })
+      .promise();
+
+    dynamodbCacheSetItemsInCacheMock.mockResolvedValueOnce();
+
+    const actual: TestHashOnlyItem[] = await testHashOnly.query(queryInput, ttl);
+    const cacheKeyItemMap: CacheKeyItemMap<TestHashOnlyItem> = buildItemsCacheMap(
+      CACHE_PREFIX_KEY,
+      testHashOnly.tableName,
+      testHashOnly.tableKeySchema,
+      actual
+    );
+
+    expect(actual).toEqual(items);
+    expect(dynamodbCacheSetItemsInCacheMock).toBeCalledWith(cacheKeyItemMap, ttl);
+  });
+
+  it('query should return an empty list. setItemsInCache should not be invoked', async () => {
+    const queryInput: DynamoDB.DocumentClient.QueryInput = {
+      TableName: testHashOnly.tableName,
+      ConsistentRead: true,
+      KeyConditionExpression: 'id = :id',
+      ExpressionAttributeValues: {
+        ':id': 'testId',
+      },
+    };
+    const ttl = 30;
+
+    const actual: TestHashOnlyItem[] = await testHashOnly.query(queryInput, ttl);
+
+    expect(actual).toEqual([]);
+    expect(dynamodbCacheSetItemsInCacheMock).not.toBeCalled();
+  });
+
+  it('query should return a list of TestHashOnlyItem records but not add items to cache because of no ttl', async () => {
+    const queryInput: DynamoDB.DocumentClient.QueryInput = {
+      TableName: testHashOnly.tableName,
+      ConsistentRead: true,
+      KeyConditionExpression: 'id = :id',
+      ExpressionAttributeValues: {
+        ':id': 'testId',
+      },
+    };
+
+    await testHashOnly.dynamoDbDocClient
+      .put({
+        TableName: testHashOnly.tableName,
+        Item: testHashOnlyItem,
+      })
+      .promise();
+
+    const actual: TestHashOnlyItem[] = await testHashOnly.query(queryInput);
+
+    expect(actual).toEqual(items);
+    expect(dynamodbCacheSetItemsInCacheMock).not.toBeCalled();
+  });
+
+  it('scan should return a list of TestHashOnlyItem records and add items to the cache', async () => {
+    const scanInput: DynamoDB.DocumentClient.ScanInput = {
+      TableName: testHashOnly.tableName,
+      ConsistentRead: true,
+    };
+    const ttl = 30;
+
+    await testHashOnly.dynamoDbDocClient
+      .put({
+        TableName: testHashOnly.tableName,
+        Item: testHashOnlyItem,
+      })
+      .promise();
+
+    dynamodbCacheSetItemsInCacheMock.mockResolvedValueOnce();
+
+    const actual: TestHashOnlyItem[] = await testHashOnly.scan(scanInput, ttl);
+    const cacheKeyItemMap: CacheKeyItemMap<TestHashOnlyItem> = buildItemsCacheMap(
+      CACHE_PREFIX_KEY,
+      testHashOnly.tableName,
+      testHashOnly.tableKeySchema,
+      actual
+    );
+
+    expect(actual).toEqual(items);
+    expect(dynamodbCacheSetItemsInCacheMock).toBeCalledWith(cacheKeyItemMap, ttl);
+  });
+
+  it('scan should return an empty list. setItemsInCache should not be invoked', async () => {
+    const scanInput: DynamoDB.DocumentClient.ScanInput = {
+      TableName: testHashOnly.tableName,
+      ConsistentRead: true,
+    };
+    const ttl = 30;
+
+    const actual: TestHashOnlyItem[] = await testHashOnly.scan(scanInput, ttl);
+
+    expect(actual).toEqual([]);
+    expect(dynamodbCacheSetItemsInCacheMock).not.toBeCalled();
+  });
+
+  it('scan should return a list of TestHashOnlyItem records but not add items to cache because of no ttl', async () => {
+    const scanInput: DynamoDB.DocumentClient.ScanInput = {
+      TableName: testHashOnly.tableName,
+      ConsistentRead: true,
+    };
+
+    await testHashOnly.dynamoDbDocClient
+      .put({
+        TableName: testHashOnly.tableName,
+        Item: testHashOnlyItem,
+      })
+      .promise();
+
+    const actual: TestHashOnlyItem[] = await testHashOnly.scan(scanInput);
+
+    expect(actual).toEqual(items);
+    expect(dynamodbCacheSetItemsInCacheMock).not.toBeCalled();
+  });
+
+  it('should put the item and store it in the cache', async () => {
+    const item2: TestHashOnlyItem = {
+      id: 'testId2',
+      test: 'testing2',
+    };
+    const ttl = 30;
+    const cacheKey = `${CACHE_PREFIX_KEY}${testHashOnly.tableName}:id-testId2`;
+
+    dynamodbCacheSetInCacheMock.mockResolvedValueOnce();
+
+    const actual: TestHashOnlyItem = await testHashOnly.put(item2, ttl);
+    const { Item } = await testHashOnly.dynamoDbDocClient
+      .get({
+        TableName: testHashOnly.tableName,
+        ConsistentRead: true,
+        Key: {
+          id: 'testId2',
+        },
+      })
+      .promise();
+
+    expect(actual).toEqual(item2);
+    expect(Item).toBeDefined();
+    expect(actual).toEqual(Item);
+    expect(dynamodbCacheSetInCacheMock).toBeCalledWith(cacheKey, actual, ttl);
+
+    await testHashOnly.dynamoDbDocClient
+      .delete({
+        TableName: testHashOnly.tableName,
+        Key: { id: 'testId2' },
+      })
+      .promise();
+  });
+
+  it('should put the item and not store it in the cache because the ttl is null', async () => {
+    const item3: TestHashOnlyItem = {
+      id: 'testId3',
+      test: 'testing3',
+    };
+
+    const actual: TestHashOnlyItem = await testHashOnly.put(item3);
+    const { Item } = await testHashOnly.dynamoDbDocClient
+      .get({
+        TableName: testHashOnly.tableName,
+        ConsistentRead: true,
+        Key: {
+          id: 'testId3',
+        },
+      })
+      .promise();
+
+    expect(actual).toEqual(item3);
+    expect(Item).toBeDefined();
+    expect(actual).toEqual(Item);
+    expect(dynamodbCacheSetInCacheMock).not.toBeCalled();
+
+    await testHashOnly.dynamoDbDocClient
+      .delete({
+        TableName: testHashOnly.tableName,
+        Key: { id: 'testId3' },
+      })
+      .promise();
+  });
+
+  it('should update the item in the table and store it in the cache', async () => {
+    const item2: TestHashOnlyItem = {
+      id: 'testId2',
+      test: 'testing2',
+    };
+    const itemUpdated: TestHashOnlyItem = {
+      id: 'testId2',
+      test: 'testing_updated',
+    };
+    await testHashOnly.dynamoDbDocClient
+      .put({
+        TableName: testHashOnly.tableName,
+        Item: item2,
+      })
+      .promise();
+
+    const givenKey: DynamoDB.DocumentClient.Key = { id: 'testId2' };
+    const givenUpdateExpression: DynamoDB.DocumentClient.UpdateExpression = 'SET #test = :test';
+    const givenExpressionAttributeNames: DynamoDB.DocumentClient.ExpressionAttributeNameMap = { '#test': 'test' };
+    const givenExpressionAttributeValues: DynamoDB.DocumentClient.ExpressionAttributeValueMap = {
+      ':test': 'testing_updated',
+    };
+    const ttl = 30;
+    const cacheKey = `${CACHE_PREFIX_KEY}${testHashOnly.tableName}:id-testId2`;
+
+    dynamodbCacheSetInCacheMock.mockResolvedValueOnce();
+
+    const actual = await testHashOnly.update(
+      givenKey,
+      givenUpdateExpression,
+      givenExpressionAttributeNames,
+      givenExpressionAttributeValues,
+      ttl
+    );
+    const { Item } = await testHashOnly.dynamoDbDocClient
+      .get({
+        TableName: testHashOnly.tableName,
+        ConsistentRead: true,
+        Key: {
+          id: 'testId2',
+        },
+      })
+      .promise();
+
+    expect(actual).toEqual(itemUpdated);
+    expect(Item).toBeDefined();
+    expect(actual).toEqual(Item);
+    expect(dynamodbCacheSetInCacheMock).toBeCalledWith(cacheKey, actual, ttl);
+
+    await testHashOnly.dynamoDbDocClient
+      .delete({
+        TableName: testHashOnly.tableName,
+        Key: { id: 'testId2' },
+      })
+      .promise();
+  });
+
+  it('should update the item in the table and not set the item in the cache - no ttl passed in', async () => {
+    const item2: TestHashOnlyItem = {
+      id: 'testId2',
+      test: 'testing2',
+    };
+    const itemUpdated: TestHashOnlyItem = {
+      id: 'testId2',
+      test: 'testing_updated',
+    };
+    await testHashOnly.dynamoDbDocClient
+      .put({
+        TableName: testHashOnly.tableName,
+        Item: item2,
+      })
+      .promise();
+
+    const givenKey: DynamoDB.DocumentClient.Key = { id: 'testId2' };
+    const givenUpdateExpression: DynamoDB.DocumentClient.UpdateExpression = 'SET #test = :test';
+    const givenExpressionAttributeNames: DynamoDB.DocumentClient.ExpressionAttributeNameMap = { '#test': 'test' };
+    const givenExpressionAttributeValues: DynamoDB.DocumentClient.ExpressionAttributeValueMap = {
+      ':test': 'testing_updated',
+    };
+
+    const actual = await testHashOnly.update(
+      givenKey,
+      givenUpdateExpression,
+      givenExpressionAttributeNames,
+      givenExpressionAttributeValues
+    );
+    const { Item } = await testHashOnly.dynamoDbDocClient
+      .get({
+        TableName: testHashOnly.tableName,
+        ConsistentRead: true,
+        Key: {
+          id: 'testId2',
+        },
+      })
+      .promise();
+
+    expect(actual).toEqual(itemUpdated);
+    expect(Item).toBeDefined();
+    expect(actual).toEqual(Item);
+    expect(dynamodbCacheSetInCacheMock).not.toBeCalled();
+
+    await testHashOnly.dynamoDbDocClient
+      .delete({
+        TableName: testHashOnly.tableName,
+        Key: { id: 'testId2' },
+      })
+      .promise();
+  });
+
+  it('should delete the item from the table', async () => {
+    const dynamodbCacheRemoveItemFromCacheMock = jest.spyOn(testHashOnly.dynamodbCache, 'removeItemFromCache');
+
+    const itemToDelete: TestHashOnlyItem = {
+      id: 'delete_me',
+      test: 'gonna be deleted',
+    };
+    await testHashOnly.dynamoDbDocClient
+      .put({
+        TableName: testHashOnly.tableName,
+        Item: itemToDelete,
+      })
+      .promise();
+
+    const givenKey: DynamoDB.DocumentClient.Key = { id: 'delete_me' };
+
+    dynamodbCacheRemoveItemFromCacheMock.mockResolvedValueOnce();
+
+    await testHashOnly.delete(givenKey);
+
+    const { Item } = await testHashOnly.dynamoDbDocClient
+      .get({
+        TableName: testHashOnly.tableName,
+        ConsistentRead: true,
+        Key: {
+          id: 'delete_me',
+        },
+      })
+      .promise();
+
+    expect(Item).not.toBeDefined();
+    expect(dynamodbCacheRemoveItemFromCacheMock).toBeCalledWith(testHashOnly.tableName, givenKey);
+  });
+});

--- a/src/__tests__/utils.spec.ts
+++ b/src/__tests__/utils.spec.ts
@@ -1,0 +1,151 @@
+import { DynamoDB } from 'aws-sdk';
+
+import { CacheKeyItemMap } from '../types';
+import { buildCacheKey, buildItemsCacheMap, buildKey } from '../utils';
+
+interface TestItem {
+  id: string;
+  timestamp: string;
+  test: string;
+}
+
+describe('buildCacheKey', () => {
+  it('should return build cache key from the given table and single HASH key value', () => {
+    const givenCachePrefix = 'test:';
+    const givenTableName = 'test';
+    const givenKey: DynamoDB.DocumentClient.Key = {
+      id: 'testId',
+    };
+    const expected = 'test:test:id-testId';
+
+    const actual = buildCacheKey(givenCachePrefix, givenTableName, givenKey);
+
+    expect(actual).toEqual(expected);
+  });
+  it('should return build cache key from the given table and compose HASH and RANGE key values', () => {
+    const givenCachePrefix = 'test:';
+    const givenTableName = 'test';
+    const givenKey: DynamoDB.DocumentClient.Key = {
+      id: 'testId',
+      timestamp: '2020-01-01 00:00:00',
+    };
+    const expected = 'test:test:id-testId:timestamp-2020-01-01 00:00:00';
+
+    const actual = buildCacheKey(givenCachePrefix, givenTableName, givenKey);
+
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('buildItemsCacheMap', () => {
+  it('should build the CacheItemKeyMap with single HASH key', () => {
+    const givenCachePrefix = 'test:';
+    const givenTableName = 'test';
+    const givenKeySchema: DynamoDB.DocumentClient.KeySchema = [
+      {
+        AttributeName: 'id',
+        KeyType: 'HASH',
+      },
+    ];
+    const givenItems: TestItem[] = [
+      {
+        id: 'testId',
+        timestamp: '2020-01-01 00:00:00',
+        test: 'testing',
+      },
+    ];
+    const expected: CacheKeyItemMap<TestItem> = {
+      ['test:test:id-testId']: {
+        id: 'testId',
+        timestamp: '2020-01-01 00:00:00',
+        test: 'testing',
+      },
+    };
+
+    const actual = buildItemsCacheMap<TestItem>(givenCachePrefix, givenTableName, givenKeySchema, givenItems);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should build the CacheItemKeyMap with a HASH and RANGE composite key', () => {
+    const givenCachePrefix = 'test:';
+    const givenTableName = 'test';
+    const givenKeySchema: DynamoDB.DocumentClient.KeySchema = [
+      {
+        AttributeName: 'id',
+        KeyType: 'HASH',
+      },
+      {
+        AttributeName: 'timestamp',
+        KeyType: 'RANGE',
+      },
+    ];
+    const givenItems: TestItem[] = [
+      {
+        id: 'testId',
+        timestamp: '2020-01-01 00:00:00',
+        test: 'testing',
+      },
+    ];
+    const expected: CacheKeyItemMap<TestItem> = {
+      ['test:test:id-testId:timestamp-2020-01-01 00:00:00']: {
+        id: 'testId',
+        timestamp: '2020-01-01 00:00:00',
+        test: 'testing',
+      },
+    };
+
+    const actual = buildItemsCacheMap<TestItem>(givenCachePrefix, givenTableName, givenKeySchema, givenItems);
+
+    expect(actual).toEqual(expected);
+  });
+});
+
+describe('buildKey', () => {
+  it('should build a key with only a HASH key', () => {
+    const givenKeySchema: DynamoDB.DocumentClient.KeySchema = [
+      {
+        AttributeName: 'id',
+        KeyType: 'HASH',
+      },
+    ];
+    const givenItem: TestItem = {
+      id: 'testId',
+      timestamp: '2020-01-01 00:00:00',
+      test: 'testing',
+    };
+    const expected: DynamoDB.DocumentClient.Key = {
+      id: 'testId',
+    };
+
+    const actual = buildKey(givenKeySchema, givenItem);
+
+    expect(actual).toEqual(expected);
+  });
+
+  it('should build a key with a HASH and RANGE key', () => {
+    const givenKeySchema: DynamoDB.DocumentClient.KeySchema = [
+      {
+        AttributeName: 'id',
+        KeyType: 'HASH',
+      },
+      {
+        AttributeName: 'timestamp',
+        KeyType: 'RANGE',
+      },
+    ];
+    const givenItem: TestItem = {
+      id: 'testId',
+      timestamp: '2020-01-01 00:00:00',
+      test: 'testing',
+    };
+    const expected: DynamoDB.DocumentClient.Key = {
+      id: 'testId',
+      timestamp: '2020-01-01 00:00:00',
+    };
+
+    const actual = buildKey(givenKeySchema, givenItem);
+
+    expect(actual).toEqual(expected);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-export const testing = (): void => console.log('testing');
+export { DynamoDBCache, DynamoDBCacheImpl } from './DynamoDBCache';
+export { DynamoDBDataSource } from './DynamoDBDataSource';

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,3 @@
+export interface CacheKeyItemMap<T = unknown> {
+  [key: string]: T;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,88 @@
+import { DynamoDB } from 'aws-sdk';
+
+import { CacheKeyItemMap } from './types';
+
+/**
+ * Build the cache key from the table and key info.
+ * The cache key format is: `${prefix}${tableName}:${...[key-value]}`
+ * Example:
+ * - `prefix`: `dynamodbcache:`
+ * - `tableName`: `test`
+ * - `key`: { ['id']: 'testId', ['timestamp']: '2020-01-01 00:00:00' }
+ * Cache Key
+ * `dynamodbcache:test:id-testId:timestamp-2020-01-01 00:00:00`
+ * @param cachePrefix the prefix for items in the cache
+ * @param tableName the name of the DynamoDB table
+ * @param key the key value for the record
+ */
+export const buildCacheKey = (cachePrefix: string, tableName: string, key: DynamoDB.DocumentClient.Key): string => {
+  const keysStr = Object.entries(key).reduce((accum: string, curr: [string, string]) => {
+    return `${accum}:${curr[0]}-${curr[1]}`;
+  }, '');
+  return `${cachePrefix}${tableName}${keysStr}`;
+};
+
+/**
+ * Build the Key from the KeySchema and item
+ * @param keySchema the tables key schema. defines the HASH, RANGE (optional) schema.
+ * @param item the item to pull values from the key for
+ */
+export function buildKey<T>(keySchema: DynamoDB.DocumentClient.KeySchema, item: T): DynamoDB.DocumentClient.Key {
+  return keySchema.reduce((prevKeys, keyElement: DynamoDB.DocumentClient.KeySchemaElement) => {
+    return {
+      ...prevKeys,
+      [keyElement.AttributeName]: item[keyElement.AttributeName],
+    };
+  }, {});
+}
+
+/**
+ * Use the key schema and items to build the Cache Key Item Map instance to use to save the items to the cache.
+ * Example:
+ * - keySchema:
+ * ```js
+ * [
+ *  {
+ *    AttributeName: 'id',
+ *    KeyType: 'HASH'
+ *  }
+ * ]
+ * ```
+ * - items;
+ * ```js
+ * [
+ *  {
+ *    id: 'testId',
+ *    test: 'testing'
+ *  }
+ * ]
+ * ```
+ * Returns:
+ * ```js
+ * {
+ *  [dynamodbcache:test:id-testId]: {
+ *    id: 'testId',
+ *    test: 'testing'
+ *  }
+ * }
+ * ```
+ * @param cachePrefix the prefix for items in the cache
+ * @param tableName the DynamoDB table name. used to build the cache key
+ * @param keySchema the tables key schema. defines the HASH, RANGE (optional) schema.
+ * @param items the items to set in the cash
+ */
+export function buildItemsCacheMap<T = unknown>(
+  cachePrefix: string,
+  tableName: string,
+  keySchema: DynamoDB.DocumentClient.KeySchema,
+  items: T[]
+): CacheKeyItemMap<T> {
+  return items.reduce((accum: {}, curr: T) => {
+    const key: DynamoDB.DocumentClient.Key = buildKey(keySchema, curr);
+    const cacheKey = buildCacheKey(cachePrefix, tableName, key);
+    return {
+      ...accum,
+      [cacheKey]: curr,
+    };
+  }, {});
+}


### PR DESCRIPTION
## Description
Add support for the DynamoDBDataSource with DynamoDBCache.
Added tests.

## Testing
Run `npm test` to run the full test suite.