### PR TITLE
Breaking Change: Consistent API for `put`, `update` and `delete`

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ const items: TestHashOnlyItem[] = await this.scan(scanInput, ttl);
 
 ### put
 
-`this.put(item, 180)`
+`this.put(putItemInput, 180)`
 
-Saves the given item to the table. If a `ttl` value is provided it will also add the item to the cache
+Saves the given item in the putItemInput to the table. If a `ttl` value is provided it will also add the item to the cache
 
 [DynamoDB.DocumentClient.put](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#put-property)
 
@@ -211,12 +211,22 @@ Saves the given item to the table. If a `ttl` value is provided it will also add
 
 ```ts
 const item: TestHashOnlyItem = {
-  id: 'testId2',
-  test: 'testing2',
-};
+      id: 'testId2',
+      test: 'testing2',
+    };
 const ttl = 30 * 60; // 30minutes
 
-const created: TestHashOnlyItem = await this.put(item, ttl);
+const putItemInput: DocumentClient.PutItemInput = {
+  TableName: testHashOnly.tableName,
+  Item: item,
+  ConditionExpression: 'id <> :value',
+  ExpressionAttributeValues: {
+    ':value': 'testing'
+  },
+  ReturnValues: 'NONE',
+};
+
+const created: TestHashOnlyItem = await testHashOnly.put(putItemInput, ttl);
 ```
 
 ### update

--- a/src/DynamoDBDataSource.ts
+++ b/src/DynamoDBDataSource.ts
@@ -111,29 +111,15 @@ export abstract class DynamoDBDataSource<ITEM = unknown, TContext = unknown> ext
 
   /**
    * Update the item in the table and reset the item in the cache
-   * @param key the key of the item in the table to update
+   * @param updateItemInput the input to be passed to dynamodb update
    * @param ttl the time-to-live value of how long to persist the item in the cache
    */
-  async update(
-    key: DynamoDB.DocumentClient.Key,
-    updateExpression: DynamoDB.DocumentClient.UpdateExpression,
-    expressionAttributeNames: DynamoDB.DocumentClient.ExpressionAttributeNameMap,
-    expressionAttributeValues: DynamoDB.DocumentClient.ExpressionAttributeValueMap,
-    ttl?: number
-  ): Promise<ITEM> {
-    const updateItemInput: DynamoDB.DocumentClient.UpdateItemInput = {
-      TableName: this.tableName,
-      Key: key,
-      ReturnValues: 'ALL_NEW',
-      UpdateExpression: updateExpression,
-      ExpressionAttributeNames: expressionAttributeNames,
-      ExpressionAttributeValues: expressionAttributeValues,
-    };
+  async update(updateItemInput: DynamoDB.DocumentClient.UpdateItemInput, ttl?: number): Promise<ITEM> {
     const output = await this.dynamoDbDocClient.update(updateItemInput).promise();
     const updated: ITEM = output.Attributes as ITEM;
 
     if (updated && ttl) {
-      const cacheKey: string = buildCacheKey(CACHE_PREFIX_KEY, this.tableName, key);
+      const cacheKey: string = buildCacheKey(CACHE_PREFIX_KEY, this.tableName, updateItemInput.Key);
       await this.dynamodbCache.setInCache(cacheKey, updated, ttl);
     }
 
@@ -142,16 +128,11 @@ export abstract class DynamoDBDataSource<ITEM = unknown, TContext = unknown> ext
 
   /**
    * Delete the given item from the table
-   * @param key the key of the item to delete from the table
+   * @param deleteItemInput the input to be passed to dynamodb delete
    */
-  async delete(key: DynamoDB.DocumentClient.Key): Promise<void> {
-    const deleteItemInput: DynamoDB.DocumentClient.DeleteItemInput = {
-      TableName: this.tableName,
-      Key: key,
-    };
-
+  async delete(deleteItemInput: DynamoDB.DocumentClient.DeleteItemInput): Promise<void> {
     await this.dynamoDbDocClient.delete(deleteItemInput).promise();
 
-    await this.dynamodbCache.removeItemFromCache(this.tableName, key);
+    await this.dynamodbCache.removeItemFromCache(this.tableName, deleteItemInput.Key);
   }
 }

--- a/src/DynamoDBDataSource.ts
+++ b/src/DynamoDBDataSource.ts
@@ -93,14 +93,11 @@ export abstract class DynamoDBDataSource<ITEM = unknown, TContext = unknown> ext
 
   /**
    * Store the item in the table and add the item to the cache
-   * @param item the item to store in the table
+   * @param putItemInput parameters to pass in to the dynamodb put operation
    * @param ttl the time-to-live value of how long to persist the item in the cache
    */
-  async put(item: ITEM, ttl?: number): Promise<ITEM> {
-    const putItemInput: DynamoDB.DocumentClient.PutItemInput = {
-      TableName: this.tableName,
-      Item: item,
-    };
+  async put(putItemInput: DynamoDB.DocumentClient.PutItemInput, ttl?: number): Promise<ITEM> {
+    const item: ITEM = putItemInput.Item as ITEM;
     await this.dynamoDbDocClient.put(putItemInput).promise();
 
     if (ttl) {

--- a/src/__tests__/DynamoDBDataSource.spec.ts
+++ b/src/__tests__/DynamoDBDataSource.spec.ts
@@ -1,7 +1,7 @@
 import { ApolloError } from 'apollo-server-errors';
 import { DataSourceConfig } from 'apollo-datasource';
 import { DynamoDB } from 'aws-sdk';
-import { ClientConfiguration } from 'aws-sdk/clients/dynamodb';
+import { ClientConfiguration, DocumentClient } from 'aws-sdk/clients/dynamodb';
 
 import { DynamoDBDataSource } from '../DynamoDBDataSource';
 import { CACHE_PREFIX_KEY } from '../DynamoDBCache';
@@ -267,7 +267,12 @@ describe('DynamoDBDataSource', () => {
 
     dynamodbCacheSetInCacheMock.mockResolvedValueOnce();
 
-    const actual: TestHashOnlyItem = await testHashOnly.put(item2, ttl);
+    const input2: DocumentClient.PutItemInput = {
+      TableName: testHashOnly.tableName,
+      Item: item2,
+    };
+
+    const actual: TestHashOnlyItem = await testHashOnly.put(input2, ttl);
     const { Item } = await testHashOnly.dynamoDbDocClient
       .get({
         TableName: testHashOnly.tableName,
@@ -297,7 +302,12 @@ describe('DynamoDBDataSource', () => {
       test: 'testing3',
     };
 
-    const actual: TestHashOnlyItem = await testHashOnly.put(item3);
+    const input3: DocumentClient.PutItemInput = {
+      TableName: testHashOnly.tableName,
+      Item: item3,
+    };
+
+    const actual: TestHashOnlyItem = await testHashOnly.put(input3);
     const { Item } = await testHashOnly.dynamoDbDocClient
       .get({
         TableName: testHashOnly.tableName,

--- a/src/__tests__/DynamoDBDataSource.spec.ts
+++ b/src/__tests__/DynamoDBDataSource.spec.ts
@@ -359,10 +359,14 @@ describe('DynamoDBDataSource', () => {
     dynamodbCacheSetInCacheMock.mockResolvedValueOnce();
 
     const actual = await testHashOnly.update(
-      givenKey,
-      givenUpdateExpression,
-      givenExpressionAttributeNames,
-      givenExpressionAttributeValues,
+      {
+        TableName: testHashOnly.tableName,
+        Key: givenKey,
+        ReturnValues: 'ALL_NEW',
+        UpdateExpression: givenUpdateExpression,
+        ExpressionAttributeNames: givenExpressionAttributeNames,
+        ExpressionAttributeValues: givenExpressionAttributeValues,
+      },
       ttl
     );
     const { Item } = await testHashOnly.dynamoDbDocClient
@@ -411,12 +415,14 @@ describe('DynamoDBDataSource', () => {
       ':test': 'testing_updated',
     };
 
-    const actual = await testHashOnly.update(
-      givenKey,
-      givenUpdateExpression,
-      givenExpressionAttributeNames,
-      givenExpressionAttributeValues
-    );
+    const actual = await testHashOnly.update({
+      TableName: testHashOnly.tableName,
+      Key: givenKey,
+      ReturnValues: 'ALL_NEW',
+      UpdateExpression: givenUpdateExpression,
+      ExpressionAttributeNames: givenExpressionAttributeNames,
+      ExpressionAttributeValues: givenExpressionAttributeValues,
+    });
     const { Item } = await testHashOnly.dynamoDbDocClient
       .get({
         TableName: testHashOnly.tableName,
@@ -458,7 +464,7 @@ describe('DynamoDBDataSource', () => {
 
     dynamodbCacheRemoveItemFromCacheMock.mockResolvedValueOnce();
 
-    await testHashOnly.delete(givenKey);
+    await testHashOnly.delete({ TableName: testHashOnly.tableName, Key: givenKey });
 
     const { Item } = await testHashOnly.dynamoDbDocClient
       .get({


### PR DESCRIPTION
Current implementation of `put` accepts the ITEM type and builds the putItemInput by providing tableName from the context before calling `dynamoDbDocClient.put()`. This function does not have consistent API signature as other sibling methods like below. All the functions receive `DocumentClient.*Input` objects apart from `put` and `update`

```
getItem(getItemInput: DynamoDB.DocumentClient.GetItemInput, ttl?: number): Promise<ITEM>;
query(queryInput: DynamoDB.DocumentClient.QueryInput, ttl?: number): Promise<ITEM[]>;
scan(scanInput: DynamoDB.DocumentClient.ScanInput, ttl?: number): Promise<ITEM[]>;
```

This PR makes the `put` in line with above methods and allow it to accept `DynamoDB.DocumentClient.PutItemInput` which is more flexible as it allows passing additional attributes. Example below

```ts
const item: TestHashOnlyItem = {
      id: 'testId2',
      test: 'testing2',
    };
const ttl = 30 * 60; // 30minutes

const putItemInput: DocumentClient.PutItemInput = {
  TableName: testHashOnly.tableName,
  Item: item,
  ConditionExpression: 'id <> :value',
  ExpressionAttributeValues: {
    ':value': 'testing'
  },
  ReturnValues: 'NONE',
};

const created: TestHashOnlyItem = await testHashOnly.put(putItemInput, ttl);
```

I would like to see this pushed to the npm through your official release.  This upgrade will break others code. So may be this can be a major release along with changes to `update`.

If you agree with this, please let me know I will fix up the `update` method as well to allow it to accept `DynamoDB.DocumentClient.UpdateItemInput` instead of separate param attributes.

PS: Good work with the DataSource Implementation 👍 