### PR TITLE
issue #9: add a DynamoDB.DocumentClient instance param

### DIFF
--- a/jest-dynalite-config.json
+++ b/jest-dynalite-config.json
@@ -10,6 +10,15 @@
       }
     },
     {
+      "TableName": "test_with_client",
+      "KeySchema": [{ "AttributeName": "id", "KeyType": "HASH" }],
+      "AttributeDefinitions": [{ "AttributeName": "id", "AttributeType": "S" }],
+      "ProvisionedThroughput": {
+        "ReadCapacityUnits": 1,
+        "WriteCapacityUnits": 1
+      }
+    },
+    {
       "TableName": "test_composite",
       "KeySchema": [
         { "AttributeName": "id", "KeyType": "HASH" },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apollo-datasource-dynamodb",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Apollo DataSource framework for AWS DynamoDB",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/DynamoDBDataSource.ts
+++ b/src/DynamoDBDataSource.ts
@@ -17,14 +17,29 @@ export abstract class DynamoDBDataSource<ITEM = unknown, TContext = unknown> ext
   dynamodbCache!: DynamoDBCache<ITEM>;
   context!: TContext;
 
-  constructor(tableName: string, tableKeySchema: DynamoDB.DocumentClient.KeySchema, config?: ClientConfiguration) {
+  /**
+   * Create a `DynamoDBDataSource` instance with the supplied params
+   * @param tableName the name of the DynamoDB table the class will be interacting with
+   * @param tableKeySchema the key structure schema of the table
+   * @param config an optional ClientConfiguration object to use in building the DynamoDB.DocumentClient
+   * @param client an optional initialized DynamoDB.Document client instance to use to set the client in the class instance
+   */
+  constructor(
+    tableName: string,
+    tableKeySchema: DynamoDB.DocumentClient.KeySchema,
+    config?: ClientConfiguration,
+    client?: DynamoDB.DocumentClient
+  ) {
     super();
     this.tableName = tableName;
     this.tableKeySchema = tableKeySchema;
-    this.dynamoDbDocClient = new DynamoDB.DocumentClient({
-      apiVersion: '2012-08-10',
-      ...config,
-    });
+    this.dynamoDbDocClient =
+      client != null
+        ? client
+        : new DynamoDB.DocumentClient({
+            apiVersion: 'latest',
+            ...config,
+          });
   }
 
   initialize({ context, cache }: DataSourceConfig<TContext>): void {

--- a/src/__tests__/DynamoDBDataSourceWithClient.spec.ts
+++ b/src/__tests__/DynamoDBDataSourceWithClient.spec.ts
@@ -1,0 +1,73 @@
+import { DataSourceConfig } from 'apollo-datasource';
+import { DynamoDB } from 'aws-sdk';
+
+import { DynamoDBDataSource } from '../DynamoDBDataSource';
+
+const { MOCK_DYNAMODB_ENDPOINT } = process.env;
+
+interface TestItem {
+  id: string;
+  item1: string;
+  item2: string;
+}
+
+class TestWithClient extends DynamoDBDataSource<TestItem> {
+  constructor(tableName: string, tableKeySchema: DynamoDB.DocumentClient.KeySchema, client: DynamoDB.DocumentClient) {
+    super(tableName, tableKeySchema, null, client);
+  }
+
+  initialize(config: DataSourceConfig<{}>): void {
+    super.initialize(config);
+  }
+}
+
+const keySchema: DynamoDB.DocumentClient.KeySchema = [
+  {
+    AttributeName: 'id',
+    KeyType: 'HASH',
+  },
+];
+
+const client: DynamoDB.DocumentClient = new DynamoDB.DocumentClient({
+  apiVersion: 'latest',
+  region: 'local',
+  endpoint: MOCK_DYNAMODB_ENDPOINT,
+  sslEnabled: false,
+});
+
+const testWithClient = new TestWithClient('test_with_client', keySchema, client);
+testWithClient.initialize({ context: {}, cache: null });
+
+const testItem: TestItem = {
+  id: 'testWithClientId',
+  item1: 'testing1',
+  item2: 'testing2',
+};
+
+beforeAll(async () => {
+  await testWithClient.dynamoDbDocClient
+    .put({
+      TableName: testWithClient.tableName,
+      Item: testItem,
+    })
+    .promise();
+});
+
+afterAll(async () => {
+  await testWithClient.dynamoDbDocClient
+    .delete({
+      TableName: testWithClient.tableName,
+      Key: { id: 'testWithClientId' },
+    })
+    .promise();
+});
+
+describe('DynamoDBDataSource With Initialized Client', () => {
+  it('initializes a new TestHashOnly and instantiates props', () => {
+    expect(testWithClient.dynamoDbDocClient).toBeDefined();
+    expect(testWithClient.dynamoDbDocClient).toEqual(client);
+    expect(testWithClient.tableName).toBeDefined();
+    expect(testWithClient.tableKeySchema).toBeDefined();
+    expect(testWithClient.dynamodbCache).toBeDefined();
+  });
+});


### PR DESCRIPTION
This PR addresses a raised issue of adding a parameter to the `DynamoDBDataSource` class `constructor` for an initialized `DynamoDB.DocumentClient` instance. This instance would then be set on the class and utilized. This will help in cases where the `DynamoDB.DocumentClient` is already initialized and available through dependency-injection, etc.

Closes #9 